### PR TITLE
Support loggin only when reached vhost_maxclients_log counter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ env:
     APXS_CHECK_CMD="../${HTTPD_VERSION}/apache/bin/apachectl -v"
     VHOST_CONF="test/mod_vhost_maxclients.conf.2.2"
   # for apache2.4.x with event
-  - HTTPD_VERSION=httpd-2.4.16 
+  - HTTPD_VERSION=httpd-2.4.17 
     HTTPD_CONFIG_OPT="--with-mpm=event"
     APR=apr-1.5.2 
     APR_UTIL=apr-util-1.5.4 
@@ -40,7 +40,7 @@ env:
     APXS_CHECK_CMD="../${HTTPD_VERSION}/apache/bin/apachectl -v"
     VHOST_CONF="test/mod_vhost_maxclients.conf.2.4"
   # for apache2.4.x with worker
-  - HTTPD_VERSION=httpd-2.4.16 
+  - HTTPD_VERSION=httpd-2.4.17 
     HTTPD_CONFIG_OPT="--with-mpm=worker"
     APR=apr-1.5.2 
     APR_UTIL=apr-util-1.5.4 
@@ -50,7 +50,7 @@ env:
     APXS_CHECK_CMD="../${HTTPD_VERSION}/apache/bin/apachectl -v"
     VHOST_CONF="test/mod_vhost_maxclients.conf.2.4"
   # for apache2.4.x with prefork
-  - HTTPD_VERSION=httpd-2.4.16 
+  - HTTPD_VERSION=httpd-2.4.17 
     HTTPD_CONFIG_OPT="--with-mpm=prefork"
     APR=apr-1.5.2 
     APR_UTIL=apr-util-1.5.4 
@@ -83,7 +83,7 @@ env:
     APXS_CHECK_CMD="../${HTTPD_VERSION}/apache/bin/apachectl -v"
     VHOST_CONF="test/mod_vhost_maxclients_per_ip.conf.2.2"
   # for apache2.4.x with event
-  - HTTPD_VERSION=httpd-2.4.16 
+  - HTTPD_VERSION=httpd-2.4.17 
     HTTPD_CONFIG_OPT="--with-mpm=event"
     APR=apr-1.5.2 
     APR_UTIL=apr-util-1.5.4 
@@ -93,7 +93,7 @@ env:
     APXS_CHECK_CMD="../${HTTPD_VERSION}/apache/bin/apachectl -v"
     VHOST_CONF="test/mod_vhost_maxclients_per_ip.conf.2.4"
   # for apache2.4.x with worker
-  - HTTPD_VERSION=httpd-2.4.16 
+  - HTTPD_VERSION=httpd-2.4.17 
     HTTPD_CONFIG_OPT="--with-mpm=worker"
     APR=apr-1.5.2 
     APR_UTIL=apr-util-1.5.4 
@@ -103,7 +103,7 @@ env:
     APXS_CHECK_CMD="../${HTTPD_VERSION}/apache/bin/apachectl -v"
     VHOST_CONF="test/mod_vhost_maxclients_per_ip.conf.2.4"
   # for apache2.4.x with prefork
-  - HTTPD_VERSION=httpd-2.4.16 
+  - HTTPD_VERSION=httpd-2.4.17 
     HTTPD_CONFIG_OPT="--with-mpm=prefork"
     APR=apr-1.5.2 
     APR_UTIL=apr-util-1.5.4 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ include /path/to/vhost.conf
     # dry-run option which don't return 503, logging only
     # VhostMaxClientsDryRun On
 
+    # logging only option which don't return 503, logging only
+    # VhostMaxClientsLogOnly 10
+
+
 </VirtualHost>
 ```
 

--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -197,7 +197,7 @@ static int vhost_maxclients_handler(request_rec *r)
           ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, ap_server_conf, "DEBUG: (increment %s): %d/%d", vhostport,
                        vhost_count, scfg->vhost_maxclients);
           /* logging only for vhost_maxclients_log */
-          if (vhost_count > scfg->vhost_maxclients_log) {
+          if (scfg->vhost_maxclients_log > 0 && vhost_count > scfg->vhost_maxclients_log) {
               ap_log_error(
                   APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
                   "NOTICE: [LOG-ONLY] [VHOST_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",

--- a/test/mod_vhost_maxclients.conf.2.2
+++ b/test/mod_vhost_maxclients.conf.2.2
@@ -5,4 +5,5 @@ ExtendedStatus On
     DocumentRoot __VHOST_DOCROOT__
     ServerName test001.example.local
     VhostMaxClients 5
+    VhostMaxClientsLogOnly 1
 </VirtualHost>

--- a/test/mod_vhost_maxclients.conf.2.4
+++ b/test/mod_vhost_maxclients.conf.2.4
@@ -6,4 +6,5 @@ ExtendedStatus On
     DocumentRoot __VHOST_DOCROOT__
     ServerName test001.example.local
     VhostMaxClients 5
+    VhostMaxClientsLogOnly 1
 </VirtualHost>

--- a/test/mod_vhost_maxclients.conf.2.4.prefork
+++ b/test/mod_vhost_maxclients.conf.2.4.prefork
@@ -6,4 +6,5 @@ ExtendedStatus On
     DocumentRoot __VHOST_DOCROOT__
     ServerName test001.example.local
     VhostMaxClients 5
+    VhostMaxClientsLogOnly 1
 </VirtualHost>


### PR DESCRIPTION
``` apache
<VirtualHost 127.0.0.1:8080>
    DocumentRoot __VHOST_DOCROOT__
    ServerName test001.example.local
    VhostMaxClients 10
    VhostMaxClientsLogOnly 5
</VirtualHost>
```

When reached VhostMaxClientsLogOnly(5), logging `NOTICE: [LOG-ONLY] [VHOST_COUNT] return 503 from...`, but return `DECLINED` which pass through next module.

When reached VhostMaxClients(10), logging `NOTICE: [VHOST_COUNT] return 503 from...`, and return `HTTP_SERVICE_UNAVAILABLE` to the client.
