### PR TITLE
Support log file path instead of error_log

### DIFF
--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -31,6 +31,7 @@
 #include "http_protocol.h"
 #include "http_core.h"
 #include "http_log.h"
+#include "util_time.h"                                                                                                   
 
 #include "ap_mpm.h"
 #include "apr_strings.h"
@@ -68,11 +69,13 @@ int ap_extended_status = 0;
 
 module AP_MODULE_DECLARE_DATA vhost_maxclients_module;
 static int vhost_maxclients_server_limit, vhost_maxclients_thread_limit;
+static apr_file_t *vhost_maxclients_log_fp = NULL;
 
 typedef struct {
 
   /* vhost max clinetns */
   int dryrun;
+  const char *log_path;
   signed int vhost_maxclients;
   signed int vhost_maxclients_log;
   signed int vhost_maxclients_per_ip;
@@ -80,11 +83,24 @@ typedef struct {
 
 } vhost_maxclients_config;
 
+static void *vhost_maxclinets_log_error(request_rec *r, char *log_body)
+{
+  char log_time[APR_CTIME_LEN];
+  char *log;
+
+  ap_recent_ctime(log_time, r->request_time);
+  log = apr_psprintf(r->pool, "%s %s\n", log_time, log_body);
+
+  apr_file_puts(log, vhost_maxclients_log_fp);
+  apr_file_flush(vhost_maxclients_log_fp);
+}
+
 static void *vhost_maxclients_create_server_config(apr_pool_t *p, server_rec *s)
 {
   vhost_maxclients_config *scfg = (vhost_maxclients_config *)apr_pcalloc(p, sizeof(*scfg));
 
   scfg->dryrun = -1;
+  scfg->log_path = NULL;
   scfg->vhost_maxclients = 0;
   scfg->vhost_maxclients_log = 0;
   scfg->vhost_maxclients_per_ip = 0;
@@ -93,17 +109,18 @@ static void *vhost_maxclients_create_server_config(apr_pool_t *p, server_rec *s)
   return scfg;
 }
 
-static void* vhost_maxclients_create_server_merge_conf(apr_pool_t* p, void* b, void* n)
+static void *vhost_maxclients_create_server_merge_conf(apr_pool_t *p, void *b, void *n)
 {
   vhost_maxclients_config *base = (vhost_maxclients_config *)b;
   vhost_maxclients_config *new = (vhost_maxclients_config *)n;
   vhost_maxclients_config *scfg = (vhost_maxclients_config *)apr_pcalloc(p, sizeof(*scfg));
 
   if (new->dryrun > -1) {
-      scfg->dryrun = new->dryrun;
+    scfg->dryrun = new->dryrun;
   } else {
-      scfg->dryrun = base->dryrun;
+    scfg->dryrun = base->dryrun;
   }
+  scfg->log_path = base->log_path;
   scfg->vhost_maxclients = new->vhost_maxclients;
   scfg->vhost_maxclients_log = new->vhost_maxclients_log;
   scfg->vhost_maxclients_per_ip = new->vhost_maxclients_per_ip;
@@ -198,21 +215,43 @@ static int vhost_maxclients_handler(request_rec *r)
                        vhost_count, scfg->vhost_maxclients);
           /* logging only for vhost_maxclients_log */
           if (scfg->vhost_maxclients_log > 0 && vhost_count > scfg->vhost_maxclients_log) {
+            if (vhost_maxclients_log_fp != NULL) {
+              vhost_maxclinets_log_error(r, apr_psprintf(r->pool, "NOTICE: [LOG-ONLY] [VHOST_COUNT] return 503 from %s "
+                                                                  ": %d / %d client_ip: %s uri: %s filename: %s",
+                                                         vhostport, vhost_count, scfg->vhost_maxclients_log, client_ip,
+                                                         r->uri, r->filename));
+            } else {
               ap_log_error(
                   APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
                   "NOTICE: [LOG-ONLY] [VHOST_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
                   vhostport, vhost_count, scfg->vhost_maxclients_log, client_ip, r->uri, r->filename);
+            }
           }
           if (vhost_count > scfg->vhost_maxclients) {
             if (scfg->dryrun > 0) {
-              ap_log_error(
-                  APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
-                  "NOTICE: [DRY-RUN] [VHOST_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
-                  vhostport, vhost_count, scfg->vhost_maxclients, client_ip, r->uri, r->filename);
+              if (vhost_maxclients_log_fp != NULL) {
+                vhost_maxclinets_log_error(r, apr_psprintf(r->pool, "NOTICE: [DRY-RUN] [VHOST_COUNT] return 503 from "
+                                                                    "%s : %d / %d client_ip: %s uri: %s filename: %s",
+                                                           vhostport, vhost_count, scfg->vhost_maxclients, client_ip,
+                                                           r->uri, r->filename));
+              } else {
+                ap_log_error(
+                    APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
+                    "NOTICE: [DRY-RUN] [VHOST_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
+                    vhostport, vhost_count, scfg->vhost_maxclients, client_ip, r->uri, r->filename);
+              }
             } else {
-              ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
+              if (vhost_maxclients_log_fp != NULL) {
+                vhost_maxclinets_log_error(
+                    r, apr_psprintf(
+                           r->pool,
                            "NOTICE: [VHOST_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
-                           vhostport, vhost_count, scfg->vhost_maxclients, client_ip, r->uri, r->filename);
+                           vhostport, vhost_count, scfg->vhost_maxclients, client_ip, r->uri, r->filename));
+              } else {
+                ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
+                             "NOTICE: [VHOST_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
+                             vhostport, vhost_count, scfg->vhost_maxclients, client_ip, r->uri, r->filename);
+              }
             }
             return (scfg->dryrun > 0) ? DECLINED : HTTP_SERVICE_UNAVAILABLE;
           }
@@ -223,14 +262,31 @@ static int vhost_maxclients_handler(request_rec *r)
               ip_count++;
               if (ip_count > scfg->vhost_maxclients_per_ip) {
                 if (scfg->dryrun > 0) {
-                  ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf, "NOTICE: [DRY-RUN] [CLIENT_COUNT] return "
-                                                                            "503 from %s : %d / %d client_ip: %s uri: "
-                                                                            "%s filename: %s",
-                               vhostport, ip_count, scfg->vhost_maxclients_per_ip, client_ip, r->uri, r->filename);
+                  if (vhost_maxclients_log_fp != NULL) {
+                    vhost_maxclinets_log_error(r,
+                                               apr_psprintf(r->pool, "NOTICE: [DRY-RUN] [CLIENT_COUNT] return 503 from "
+                                                                     "%s : %d / %d client_ip: %s uri: %s filename: %s",
+                                                            vhostport, ip_count, scfg->vhost_maxclients_per_ip,
+                                                            client_ip, r->uri, r->filename));
+                  } else {
+                    ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf, "NOTICE: [DRY-RUN] [CLIENT_COUNT] return "
+                                                                              "503 from %s : %d / %d client_ip: %s "
+                                                                              "uri: %s filename: %s",
+                                 vhostport, ip_count, scfg->vhost_maxclients_per_ip, client_ip, r->uri, r->filename);
+                  }
                 } else {
-                  ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
+                  if (vhost_maxclients_log_fp != NULL) {
+                    vhost_maxclinets_log_error(
+                        r, apr_psprintf(
+                               r->pool,
                                "NOTICE: [CLIENT_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
-                               vhostport, ip_count, scfg->vhost_maxclients_per_ip, client_ip, r->uri, r->filename);
+                               vhostport, ip_count, scfg->vhost_maxclients_per_ip, client_ip, r->uri, r->filename));
+                  } else {
+                    ap_log_error(
+                        APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
+                        "NOTICE: [CLIENT_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
+                        vhostport, ip_count, scfg->vhost_maxclients_per_ip, client_ip, r->uri, r->filename);
+                  }
                 }
                 return (scfg->dryrun > 0) ? DECLINED : HTTP_SERVICE_UNAVAILABLE;
               }
@@ -288,6 +344,16 @@ static const char *set_vhost_maxclientsvhost_log(cmd_parms *parms, void *mconfig
   return NULL;
 }
 
+static const char *set_vhost_maxclientsvhost_log_path(cmd_parms *parms, void *mconfig, const char *arg1)
+{
+  vhost_maxclients_config *scfg =
+      (vhost_maxclients_config *)ap_get_module_config(parms->server->module_config, &vhost_maxclients_module);
+
+  scfg->log_path = arg1;
+
+  return NULL;
+}
+
 static const char *set_vhost_maxclientsvhost_perip(cmd_parms *parms, void *mconfig, const char *arg1)
 {
   vhost_maxclients_config *scfg =
@@ -324,6 +390,8 @@ static command_rec vhost_maxclients_cmds[] = {
                   "maximum connections per Vhost"),
     AP_INIT_TAKE1("VhostMaxClientsLogOnly", set_vhost_maxclientsvhost_log, NULL, RSRC_CONF | ACCESS_CONF,
                   "loggign only: maximum connections per Vhost"),
+    AP_INIT_TAKE1("VhostMaxClientsLogPath", set_vhost_maxclientsvhost_log_path, NULL, RSRC_CONF | ACCESS_CONF,
+                  "logging file path instead of error_log"),
     AP_INIT_TAKE1("VhostMaxClientsPerIP", set_vhost_maxclientsvhost_perip, NULL, RSRC_CONF | ACCESS_CONF,
                   "maximum connections per IP of Vhost"),
     AP_INIT_ITERATE("IgnoreVhostMaxClientsExt", set_vhost_ignore_extensions, NULL, ACCESS_CONF | RSRC_CONF,
@@ -335,6 +403,8 @@ static int vhost_maxclients_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *pt
 {
   void *data;
   const char *userdata_key = "vhost_maxclients_init";
+  vhost_maxclients_config *scfg =
+      (vhost_maxclients_config *)ap_get_module_config(server->module_config, &vhost_maxclients_module);
 
   apr_pool_userdata_get(&data, userdata_key, server->process->pool);
 
@@ -348,6 +418,15 @@ static int vhost_maxclients_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *pt
   ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
                MODULE_NAME "/" MODULE_VERSION " enabled: %d/%d thread_limit/server_limit",
                vhost_maxclients_thread_limit, vhost_maxclients_server_limit);
+
+  /* open custom log instead of error_log */
+  if (apr_file_open(&vhost_maxclients_log_fp, scfg->log_path, APR_WRITE | APR_APPEND | APR_CREATE, APR_OS_DEFAULT, p) !=
+      APR_SUCCESS) {
+    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "%s ERROR %s: vhost_maxclients log file oepn failed: %s", MODULE_NAME,
+                 __func__, scfg->log_path);
+
+    return HTTP_INTERNAL_SERVER_ERROR;
+  }
 
   return OK;
 }
@@ -363,10 +442,10 @@ AP_DECLARE_MODULE(vhost_maxclients) = {
 #else
 module AP_MODULE_DECLARE_DATA vhost_maxclients_module = {
 #endif
-    STANDARD20_MODULE_STUFF, NULL,         /* create per-dir config structures     */
-    NULL,                                  /* merge  per-dir    config structures  */
-    vhost_maxclients_create_server_config, /* create per-server config
-                                              structures  */
-    vhost_maxclients_create_server_merge_conf,                                  /* merge  per-server config structures  */
-    vhost_maxclients_cmds,                 /* table of config file commands        */
+    STANDARD20_MODULE_STUFF, NULL,             /* create per-dir config structures     */
+    NULL,                                      /* merge  per-dir    config structures  */
+    vhost_maxclients_create_server_config,     /* create per-server config
+                                                  structures  */
+    vhost_maxclients_create_server_merge_conf, /* merge  per-server config structures  */
+    vhost_maxclients_cmds,                     /* table of config file commands        */
     vhost_maxclients_register_hooks};

--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -420,12 +420,14 @@ static int vhost_maxclients_init(apr_pool_t *p, apr_pool_t *plog, apr_pool_t *pt
                vhost_maxclients_thread_limit, vhost_maxclients_server_limit);
 
   /* open custom log instead of error_log */
-  if (apr_file_open(&vhost_maxclients_log_fp, scfg->log_path, APR_WRITE | APR_APPEND | APR_CREATE, APR_OS_DEFAULT, p) !=
-      APR_SUCCESS) {
-    ap_log_error(APLOG_MARK, APLOG_ERR, 0, NULL, "%s ERROR %s: vhost_maxclients log file oepn failed: %s", MODULE_NAME,
-                 __func__, scfg->log_path);
+  if (scfg->log_path != NULL) {
+    if (apr_file_open(&vhost_maxclients_log_fp, scfg->log_path, APR_WRITE | APR_APPEND | APR_CREATE, APR_OS_DEFAULT, p) !=
+        APR_SUCCESS) {
+      ap_log_error(APLOG_MARK, APLOG_EMERG, 0, server, "%s ERROR %s: vhost_maxclients log file oepn failed: %s", MODULE_NAME,
+                   __func__, scfg->log_path);
 
-    return HTTP_INTERNAL_SERVER_ERROR;
+      return HTTP_INTERNAL_SERVER_ERROR;
+    }
   }
 
   return OK;

--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -216,7 +216,7 @@ static int vhost_maxclients_handler(request_rec *r)
           /* logging only for vhost_maxclients_log */
           if (scfg->vhost_maxclients_log > 0 && vhost_count > scfg->vhost_maxclients_log) {
             if (vhost_maxclients_log_fp != NULL) {
-              vhost_maxclinets_log_error(r, apr_psprintf(r->pool, "NOTICE: [LOG-ONLY] [VHOST_COUNT] return 503 from %s "
+              vhost_maxclinets_log_error(r, apr_psprintf(r->pool, "[LOG-ONLY] [VHOST_COUNT] return 503 from %s "
                                                                   ": %d / %d client_ip: %s uri: %s filename: %s",
                                                          vhostport, vhost_count, scfg->vhost_maxclients_log, client_ip,
                                                          r->uri, r->filename));
@@ -230,7 +230,7 @@ static int vhost_maxclients_handler(request_rec *r)
           if (vhost_count > scfg->vhost_maxclients) {
             if (scfg->dryrun > 0) {
               if (vhost_maxclients_log_fp != NULL) {
-                vhost_maxclinets_log_error(r, apr_psprintf(r->pool, "NOTICE: [DRY-RUN] [VHOST_COUNT] return 503 from "
+                vhost_maxclinets_log_error(r, apr_psprintf(r->pool, "[DRY-RUN] [VHOST_COUNT] return 503 from "
                                                                     "%s : %d / %d client_ip: %s uri: %s filename: %s",
                                                            vhostport, vhost_count, scfg->vhost_maxclients, client_ip,
                                                            r->uri, r->filename));
@@ -245,7 +245,7 @@ static int vhost_maxclients_handler(request_rec *r)
                 vhost_maxclinets_log_error(
                     r, apr_psprintf(
                            r->pool,
-                           "NOTICE: [VHOST_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
+                           "[VHOST_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
                            vhostport, vhost_count, scfg->vhost_maxclients, client_ip, r->uri, r->filename));
               } else {
                 ap_log_error(APLOG_MARK, APLOG_NOTICE, 0, ap_server_conf,
@@ -264,7 +264,7 @@ static int vhost_maxclients_handler(request_rec *r)
                 if (scfg->dryrun > 0) {
                   if (vhost_maxclients_log_fp != NULL) {
                     vhost_maxclinets_log_error(r,
-                                               apr_psprintf(r->pool, "NOTICE: [DRY-RUN] [CLIENT_COUNT] return 503 from "
+                                               apr_psprintf(r->pool, "[DRY-RUN] [CLIENT_COUNT] return 503 from "
                                                                      "%s : %d / %d client_ip: %s uri: %s filename: %s",
                                                             vhostport, ip_count, scfg->vhost_maxclients_per_ip,
                                                             client_ip, r->uri, r->filename));
@@ -279,7 +279,7 @@ static int vhost_maxclients_handler(request_rec *r)
                     vhost_maxclinets_log_error(
                         r, apr_psprintf(
                                r->pool,
-                               "NOTICE: [CLIENT_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
+                               "[CLIENT_COUNT] return 503 from %s : %d / %d client_ip: %s uri: %s filename: %s",
                                vhostport, ip_count, scfg->vhost_maxclients_per_ip, client_ip, r->uri, r->filename));
                   } else {
                     ap_log_error(


### PR DESCRIPTION
```
VhostMaxClientsLogPath /usr/local/apache/logs/vhost_maxclients.log
```

```
$ tail -f /usr/local/apache/logs/vhost_maxclients.log
Fri Nov 06 00:28:41 2015 [LOG-ONLY] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 2 / 1 client_ip: 119.170.71.29 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
Fri Nov 06 00:28:44 2015 [LOG-ONLY] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 2 / 1 client_ip: 119.170.71.29 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
Fri Nov 06 00:28:46 2015 [LOG-ONLY] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 2 / 1 client_ip: 119.170.71.29 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
Fri Nov 06 00:29:00 2015 [LOG-ONLY] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 2 / 1 client_ip: 221.113.50.254 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
Fri Nov 06 00:29:00 2015 [LOG-ONLY] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 3 / 1 client_ip: 221.113.50.254 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
Fri Nov 06 00:29:00 2015 [DRY-RUN] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 3 / 2 client_ip: 221.113.50.254 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
Fri Nov 06 00:29:03 2015 [LOG-ONLY] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 2 / 1 client_ip: 124.26.38.63 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
Fri Nov 06 00:29:03 2015 [LOG-ONLY] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 2 / 1 client_ip: 124.26.38.63 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
Fri Nov 06 00:29:03 2015 [LOG-ONLY] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 3 / 1 client_ip: 124.26.38.63 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
Fri Nov 06 00:29:03 2015 [DRY-RUN] [VHOST_COUNT] return 503 from blog.matsumoto-r.jp:8080 : 3 / 2 client_ip: 124.26.38.63 uri: /wp-admin/admin-ajax.php filename: /usr/local/apache/htdocs/blog/wp-admin/admin-ajax.php
```
