### PR TITLE
Support time slotting to enable the limit

### DIFF
--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -458,11 +458,11 @@ static const char *set_vhost_maxclients_time(cmd_parms *parms, void *mconfig, co
   scfg->vhost_maxclients_time_to = atoi(arg2);
 
   if(scfg->vhost_maxclients_time_from < 0 || scfg->vhost_maxclients_time_from > 2359){
-    return "the limit time from invalid number";
+    return "VhostMaxClientsTimeSlot_From is invalid. should be set range 0 < VhostMaxClientsTimeSlot_From < 2359";
   }
 
   if (scfg->vhost_maxclients_time_to < 0 || scfg->vhost_maxclients_time_to > 2359){
-    return "the limit time to invalid number";
+    return "VhostMaxClientsTimeSlot_To is invalid. should be set range 0 < VhostMaxClientsTimeSlot_To < 2359";
   }
 
   return NULL;

--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -482,7 +482,7 @@ static command_rec vhost_maxclients_cmds[] = {
     AP_INIT_ITERATE("IgnoreVhostMaxClientsExt", set_vhost_ignore_extensions, NULL, ACCESS_CONF | RSRC_CONF,
                   "Set Ignore Extensions."),
     AP_INIT_TAKE2("VhostMaxClientsTimeSlot", set_vhost_maxclients_time, NULL, RSRC_CONF | ACCESS_CONF,
-                  "Set Limit time."),
+                  "Time to enable the VhostMaxClients. (default 0:00 ~ 23:59)"),
     {NULL},
 };
 

--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -195,10 +195,10 @@ static int check_extension(char *filename, apr_array_header_t *exts)
 
 static int check_time(apr_pool_t *p, unsigned int from, unsigned int to)
 {
+  unsigned int cur;
+
   apr_time_exp_t tm;
   apr_time_exp_lt(&tm, apr_time_now());
-
-  unsigned int cur;
   cur = atoi(apr_psprintf(p, "%02d%02d", tm.tm_hour, tm.tm_min));
 
   if (from > to){

--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -481,7 +481,7 @@ static command_rec vhost_maxclients_cmds[] = {
                   "maximum connections per IP of Vhost"),
     AP_INIT_ITERATE("IgnoreVhostMaxClientsExt", set_vhost_ignore_extensions, NULL, ACCESS_CONF | RSRC_CONF,
                   "Set Ignore Extensions."),
-    AP_INIT_TAKE2("VhostMaxClientsTime", set_vhost_maxclients_time, NULL, RSRC_CONF | ACCESS_CONF,
+    AP_INIT_TAKE2("VhostMaxClientsTimeSlot", set_vhost_maxclients_time, NULL, RSRC_CONF | ACCESS_CONF,
                   "Set Limit time."),
     {NULL},
 };

--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -193,7 +193,7 @@ static int check_extension(char *filename, apr_array_header_t *exts)
   return 0;
 }
 
-static int check_time(apr_pool_t *p, unsigned int from, unsigned int to)
+static int check_time_slot(apr_pool_t *p, unsigned int from, unsigned int to)
 {
   unsigned int cur;
 
@@ -260,7 +260,7 @@ static int vhost_maxclients_handler(request_rec *r)
   }
 
   /* check time */
-  if (check_time(r->pool, scfg->vhost_maxclients_time_from, scfg->vhost_maxclients_time_to)) {
+  if (check_time_slot(r->pool, scfg->vhost_maxclients_time_from, scfg->vhost_maxclients_time_to)) {
     return DECLINED;
   }
 

--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -193,19 +193,19 @@ static int check_extension(char *filename, apr_array_header_t *exts)
   return 0;
 }
 
-static int check_time(apr_pool_t *p, unsigned int time_from, unsigned int time_to)
+static int check_time(apr_pool_t *p, unsigned int from, unsigned int to)
 {
-  apr_time_exp_t reqtime_result;
-  apr_time_exp_lt(&reqtime_result, apr_time_now());
+  apr_time_exp_t tm;
+  apr_time_exp_lt(&tm, apr_time_now());
 
-  unsigned int cur_hourmin;
-  cur_hourmin = atoi(apr_psprintf(p, "%02d%02d", reqtime_result.tm_hour, reqtime_result.tm_min));
+  unsigned int cur;
+  cur = atoi(apr_psprintf(p, "%02d%02d", tm.tm_hour, tm.tm_min));
 
-  if (time_from > time_to){
-    time_to += 2400;
+  if (from > to){
+    to += 2400;
   }
 
-  if ((time_from < cur_hourmin) && (time_to > cur_hourmin)){
+  if ((from < cur) && (to > cur)){
     return 0;
   }
 


### PR DESCRIPTION
Set `VhostMaxClientsTimeFrom` , `VhostMaxClientsTimeTo`.
You can limit within the specified time.

_example_

```
<VirtualHost *>
    DocumentRoot /var/www/html
    ServerName localhost
    VhostMaxClients 1
    VhostMaxClientsTimeFrom 2300
    VhostMaxClientsTimeTo   0230
</VirtualHost>
```
- request_time = 1700 > disable
- request_time = 2330 > enable

---

and fixed typo.  `vhost_maxclinets_log_error` > `vhost_maxclients_log_error`
