### PR TITLE
正規表現で特定の文字列に一致するrequestを除外できるようにした

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,9 @@ include /path/to/vhost.conf
     # Time to enable the VhostMaxClients from 17:00 to 23:00 
     # VhostMaxClientsTimeSlot 1700 2300
 
+    # Ignore Requests if it match regular expression.
+    # IgnoreVhostMaxClientsRequestRegexp '[jpg|gif|png] HTTP/1.[01]$'
+
 
 </VirtualHost>
 ```

--- a/test/all-test-run.sh
+++ b/test/all-test-run.sh
@@ -14,3 +14,7 @@ set -eux
 # Timeslot test
 ./setup/timeslot.sh
 ./test-case/timeslot.sh
+
+# RequestRegexp test
+./setup/regexp.sh
+./test-case/regexp.sh

--- a/test/setup/regexp.sh
+++ b/test/setup/regexp.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+CUR_DIR=`pwd`
+MAKE_DIR=${CUR_DIR}/../
+BUILD_DIR=${CUR_DIR}/build
+
+cp `${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir`/`${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q progname`.conf \
+  `${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir`/`${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q progname`.conf.orig
+
+grep -q "IgnoreVhostMaxClientsRequestRegexp" `${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir`/`${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q progname`.conf || \
+  echo "IgnoreVhostMaxClientsRequestRegexp .cgi" >> `${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir`/`${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q progname`.conf
+
+cd ${MAKE_DIR}
+make APXS=${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs APACHECTL=${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apachectl stop
+sleep 1
+make APXS=${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs APACHECTL=${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apachectl start
+sleep 2
+

--- a/test/test-case/regexp.sh
+++ b/test/test-case/regexp.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -eux
+
+CUR_DIR=`pwd`
+MAKE_DIR=${CUR_DIR}/../
+BUILD_DIR=${CUR_DIR}/build
+
+${BUILD_DIR}/ab-mruby/ab-mruby -m test-case/regexp/check.rb -M test-case/regexp/test.rb http://127.0.0.1:8080/cgi-bin/sleep.cgi
+
+killall httpd && sleep 1
+
+# restore default configuration
+mv `${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir`/`${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q progname`.conf.orig \
+  `${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q sysconfdir`/`${BUILD_DIR}/${HTTPD_VERSION}/apache/bin/apxs -q progname`.conf

--- a/test/test-case/regexp/check.rb
+++ b/test/test-case/regexp/check.rb
@@ -1,0 +1,26 @@
+# Usage: ./ab-mruby -m bench.rb [http[s]://]hostname[:port]/path
+
+target_hosts = ["127.0.0.1"]
+target_paths = ["/cgi-bin/sleep.cgi"]
+
+unless target_paths.include? get_config("TargetPath")
+  puts "invalid path #{get_config("TargetPath")}"
+  exit
+end
+
+unless target_hosts.include? get_config("TargetHost")
+  puts "invalid host #{get_config("TargetHost")}"
+  exit
+end
+
+add_config(
+  "TotalRequests"         => 10,                       # int
+  "Concurrency"           => 10,                        # int max 20000
+  "KeepAlive"             => true,                      # true or false or nil
+  "ShowProgress"          => false,                      # true, false or nil
+  "ShowPercentile"        => false,                      # true, false or nil
+  "ShowConfidence"        => false,                      # true, false or nil
+  "VerboseLevel"          => 1,                         # int 1 ~ 5
+  "AddHeader"             => 'Host: test001.example.local',
+)
+

--- a/test/test-case/regexp/test.rb
+++ b/test/test-case/regexp/test.rb
@@ -1,0 +1,28 @@
+# print ab-mruby headers
+print <<EOS
+======================================================================
+This is ab-mruby using ApacheBench Version 2.3 <$Revision: 1430300 $>
+Licensed to MATSUMOTO Ryosuke, https://github.com/matsumoto-r/ab-mruby
+
+                            TEST PHASE
+           (concurrent connection under vhot maxclients)
+
+======================================================================
+EOS
+
+# define test suite
+test_suite do
+  "TargetServerHost".should_be               "127.0.0.1"
+  "TargetServerPort".should_be               8080
+  "TargetDocumentPath".should_be             "/cgi-bin/sleep.cgi"
+  "WriteErrors".should_be                    0
+  "CompleteRequests".should_be               10
+  "ConnetcErrors".should_be                  0
+  "ReceiveErrors".should_be                  0
+  "ExceptionsErrors".should_be               0
+  "Non2xxResponses".should_be                0
+  "LengthErrors".should_be                   0
+  "FailedRequests".should_be                 0
+end
+
+test_run


### PR DESCRIPTION
正規表現で指定した内容に一致するRequestはvhost_max_clientsのMaxClientsの対象外としました。

If Requests match IgnoreVhostMaxClientsRequestRegexp param , mod_vhost_maxclients don't count it as MaxClients.