### PR TITLE
Fixed segv when request filename is null

### DIFF
--- a/mod_vhost_maxclients.c
+++ b/mod_vhost_maxclients.c
@@ -256,6 +256,10 @@ static int vhost_maxclients_handler(request_rec *r)
     return DECLINED;
   }
 
+  if (r->filename == NULL) {
+    return DECLINED;
+  }
+
   if (!ap_extended_status) {
     ap_log_error(APLOG_MARK, APLOG_DEBUG, 0, ap_server_conf, "DEBUG: only used when ExtendedStatus On");
     return DECLINED;


### PR DESCRIPTION
This PR fixed segv when the request filename is null.

It is a problem when using mod_vhost_maxclients with mod_pagespeed in my environment .

- segv line

  https://github.com/matsumotory/mod_vhost_maxclients/blob/0641c28bc70ded76880eac51222cc9410c315085/mod_vhost_maxclients.c#L196

- backtrace

  ```
  #0  0x00007fffe486766b in check_extension (r=0x555555dd9dc0) at mod_vhost_maxclients.c:238
  #1  vhost_maxclients_handler (r=0x555555dd9dc0) at mod_vhost_maxclients.c:265
  #2  0x00005555555a1ac0 in ap_run_access_checker (r=0x555555dd9dc0) at request.c:87
  #3  0x00005555555a4afa in ap_process_request_internal (r=0x555555dd9dc0) at request.c:229
  #4  0x00005555555c2f78 in ap_process_async_request (r=0x555555dd9dc0) at http_request.c:315
  #5  0x00005555555c30ef in ap_process_request (r=0x555555dd9dc0) at http_request.c:363
  #6  0x00005555555bf382 in ap_process_http_sync_connection (c=0x555555d30410) at http_core.c:190
  #7  ap_process_http_connection (c=0x555555d30410) at http_core.c:231
  #8  0x00005555555b6630 in ap_run_process_connection (c=0x555555d30410) at connection.c:41
  #9  0x00007fffef696852 in child_main (child_num_arg=<value optimized out>) at prefork.c:704
  #10 0x00007fffef696a8b in make_child (s=0x55555581b320, slot=0) at prefork.c:746
  #11 0x00007fffef6976b7 in prefork_run (_pconf=<value optimized out>, plog=0x55555581f358, s=0x55555581b320) at prefork.c:956
  #12 0x000055555559127e in ap_run_mpm (pconf=0x5555557f2138, plog=0x55555581f358, s=0x55555581b320) at mpm_common.c:98
  #13 0x000055555558b2d1 in main (argc=2, argv=0x7fffffffe598) at main.c:777
  ```

- report

  ```
  (gdb) run -X
  The program being debugged has been started already.
  Start it from the beginning? (y or n) y
  Starting program: /usr/sbin/httpd -X
  warning: no loadable sections found in added symbol-file system-supplied DSO at 0x7ffff7ffa000
  [Thread debugging using libthread_db enabled]
  warning: Temporarily disabling breakpoints for unloaded shared library "/etc/httpd/modules/mod_vhost_maxclients.so"

  Breakpoint 1, vhost_maxclients_handler (r=0x555555dd9e20) at mod_vhost_maxclients.c:255
  255	  if (r->hostname == NULL) {
  (gdb) s
  259	  if (!ap_extended_status) {
  (gdb) s
  265	  if (check_extension(r->filename, scfg->ignore_extensions)) {
  (gdb) s
  check_extension (r=0x555555dd9e20) at mod_vhost_maxclients.c:194
  194	  for (i = 0; i < exts->nelts; i++) {
  (gdb) p exts
  $12 = (apr_array_header_t *) 0x5555558f9e08
  (gdb) p ((char **)exts->elts)[i]
  $13 = 0x55555598bed0 ".jpg"
  (gdb) p filename
  $14 = 0x0
  (gdb) p strlen(filename)

  Program received signal SIGSEGV, Segmentation fault.
  0x00007ffff66fa94f in __strlen_sse42 () from /lib64/libc.so.6
  The program being debugged was signaled while in a function called from GDB.
  GDB remains in the frame where the signal was received.
  To change this behavior use "set unwindonsignal on".
  Evaluation of the expression containing the function
  (__strlen_sse42) will be abandoned.
  ```


With this patch it works in my environment.

please check.
